### PR TITLE
fix(ci): update workflow to use yarn instead of npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: 'yarn'
 
-      - run: npm ci --legacy-peer-deps
+      - run: yarn install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud


### PR DESCRIPTION
- Changed cache from 'npm' to 'yarn'
- Replaced 'npm ci --legacy-peer-deps' with 'yarn install --frozen-lockfile'
- This fixes CI build failures due to missing package-lock.json (workspace uses yarn)