### PR TITLE
fix(ci): disconnect from Nx Cloud to resolve authorization issues

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,6 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "6853ccf64f9ae67387f7c881",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",


### PR DESCRIPTION
- Removed nxCloudId from nx.json to completely disconnect from Nx Cloud
- Simplified CI workflow to run locally without cloud dependencies
- This fixes the 'workspace unable to be authorized' error in CI
- All builds and tests continue to work locally with full Nx functionality